### PR TITLE
Fix `duplicate symbol '_hasListeners'`

### DIFF
--- a/ios/quadpay-merchant-sdk-react-native/quadpay-merchant-sdk-react-native/QuadPayBridge.m
+++ b/ios/quadpay-merchant-sdk-react-native/quadpay-merchant-sdk-react-native/QuadPayBridge.m
@@ -10,7 +10,7 @@
 @implementation QuadPayBridge
 RCT_EXPORT_MODULE();
 
-bool hasListeners;
+static bool hasListeners = NO;
 
 -(void)startObserving {
     hasListeners = YES;


### PR DESCRIPTION
```
duplicate symbol '_hasListeners' in:
    /xxx/Library/Developer/Xcode/DerivedData/xxx-enqorveqxgntgycjpwyqvxjjinmq/Build/Products/Debug-iphoneos/braze-react-native-sdk/libbraze-react-native-sdk.a(BrazeReactBridge.o)
    /xxx/Library/Developer/Xcode/DerivedData/xxx-enqorveqxgntgycjpwyqvxjjinmq/Build/Products/Debug-iphoneos/quadpay-merchant-sdk-react-native/libquadpay-merchant-sdk-react-native.a(QuadPayBridge.o)
ld: 1 duplicate symbol for architecture arm64
```

* https://stackoverflow.com/questions/71500066/duplicate-symbol-haslisteners-react-native
* https://github.com/callstack/react-native-socket-mobile/issues/3
* https://github.com/innoveit/react-native-ble-manager/pull/1029

Created a pull request on the Braze side too.
https://github.com/braze-inc/braze-react-native-sdk/pull/248